### PR TITLE
fix: make plugin usable on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "bugs": "https://github.com/adriencaccia/serverless-analyze-bundle-plugin/issues",
   "dependencies": {
     "@babel/runtime": "^7.18.6",
-    "check-node-version": "^4.2.1"
+    "check-node-version": "^4.2.1",
+    "node-stream-zip": "^1.15.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.18.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6713,6 +6713,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-stream-zip@npm:^1.15.0":
+  version: 1.15.0
+  resolution: "node-stream-zip@npm:1.15.0"
+  checksum: 0b73ffbb09490e479c8f47038d7cba803e6242618fbc1b71c26782009d388742ed6fb5ce6e9d31f528b410249e7eb1c6e7534e9d3792a0cafd99813ac5a35107
+  languageName: node
+  linkType: hard
+
 "nopt@npm:^5.0.0":
   version: 5.0.0
   resolution: "nopt@npm:5.0.0"
@@ -7878,6 +7885,7 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     husky: ^8.0.1
     lint-staged: ^12.5.0
+    node-stream-zip: ^1.15.0
     prettier: ^2.7.1
     serverless: ^3.21.0
     standard-version: ^9.5.0


### PR DESCRIPTION
- replace usage of mkdir CLI with equivalent Node API
- replace usage of unzip CLI with node-stream-zip lib
- use os.tempdir() for getting a cross-platform temp directory
- replace path concatenation with join/normalize otherwise fileName.includes(handlerPath)
  never succeeds because of path separator mismatch

Closes #7