### PR TITLE
fix: set metafile flag in a way that prevents Serverless v3.x from overwriting it

### DIFF
--- a/plugin/serverlessAnalyzeBundle.ts
+++ b/plugin/serverlessAnalyzeBundle.ts
@@ -32,14 +32,6 @@ export class ServerlessAnalyzeBundlePlugin implements Plugin {
       },
     };
     this.hooks = {
-      'before:package:initialize': () => {
-        const { analyze } = this.options;
-        if (analyze === undefined) {
-          return;
-        }
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        this.serverless.service.custom.esbuild.metafile = true;
-      },
       'after:package:finalize': async () => {
         const { analyze } = this.options;
         if (analyze === undefined) {
@@ -48,5 +40,15 @@ export class ServerlessAnalyzeBundlePlugin implements Plugin {
         await this.bundleVisualizer();
       },
     };
+
+    // The plugin requires metafile option to be true
+    // We set it here (and not within a hook) because Serverless Framework keeps copies of service configuration
+    // therefore overwriting changes made by hook functions
+    const { analyze } = this.options;
+    if (analyze === undefined) {
+      return;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    this.serverless.service.custom.esbuild.metafile = true;
   }
 }


### PR DESCRIPTION
I moved the setting of metafile flag to the constructor, as this seems to work correctly on the most recent Serverless v3 versions.

Closes #8